### PR TITLE
Fix ApplicationDbContext class, must specify User and Role custom classes

### DIFF
--- a/IdentityManagerUI/Areas/IdentityManager/Views/Home/Roles.cshtml
+++ b/IdentityManagerUI/Areas/IdentityManager/Views/Home/Roles.cshtml
@@ -126,7 +126,6 @@
                             $('#editForm input[name=id]').val(data.id);
 
                             $.each(data.claims, function (index, value) {
-                                //Key/Value props not camel cased (https://github.com/dotnet/corefx/issues/41309)
                                 $('#claimsTable tbody').append('<tr><td data-field="key">' + value.Key + '</td>' +
                                     '<td data-field="value">' + value.Value + '</td><td><a class="removeClaim" href="#">Remove</a></td></tr>');
                             });

--- a/IdentityManagerUI/Areas/IdentityManager/Views/Home/Roles.cshtml
+++ b/IdentityManagerUI/Areas/IdentityManager/Views/Home/Roles.cshtml
@@ -127,8 +127,8 @@
 
                             $.each(data.claims, function (index, value) {
                                 //Key/Value props not camel cased (https://github.com/dotnet/corefx/issues/41309)
-                                $('#claimsTable tbody').append('<tr><td data-field="Key">' + value.Key + '</td>' +
-                                    '<td data-field="Value">' + value.Value + '</td><td><a class="removeClaim" href="#">Remove</a></td></tr>');
+                                $('#claimsTable tbody').append('<tr><td data-field="key">' + value.Key + '</td>' +
+                                    '<td data-field="value">' + value.Value + '</td><td><a class="removeClaim" href="#">Remove</a></td></tr>');
                             });
 
                             $('#editModal').modal({ backdrop: 'static' });

--- a/IdentityManagerUI/Areas/IdentityManager/Views/Home/Users.cshtml
+++ b/IdentityManagerUI/Areas/IdentityManager/Views/Home/Users.cshtml
@@ -178,7 +178,6 @@
                             });
 
                             $.each(data.claims, function (index, value) {
-                                //Key/Value props not camel cased (https://github.com/dotnet/corefx/issues/41309)
                                 $('#claimsTable tbody').append('<tr><td data-field="key">' + value.Key + '</td>' +
                                     '<td data-field="value">' + value.Value + '</td><td><a class="removeClaim" href="#">Remove</a></td></tr>');
                             });

--- a/IdentityManagerUI/Areas/IdentityManager/Views/Home/Users.cshtml
+++ b/IdentityManagerUI/Areas/IdentityManager/Views/Home/Users.cshtml
@@ -179,8 +179,8 @@
 
                             $.each(data.claims, function (index, value) {
                                 //Key/Value props not camel cased (https://github.com/dotnet/corefx/issues/41309)
-                                $('#claimsTable tbody').append('<tr><td data-field="Key">' + value.Key + '</td>' +
-                                    '<td data-field="Value">' + value.Value + '</td><td><a class="removeClaim" href="#">Remove</a></td></tr>');
+                                $('#claimsTable tbody').append('<tr><td data-field="key">' + value.Key + '</td>' +
+                                    '<td data-field="value">' + value.Value + '</td><td><a class="removeClaim" href="#">Remove</a></td></tr>');
                             });
 
                             $('#editModal').modal({ backdrop: 'static' });

--- a/WebApplication1/Data/ApplicationDbContext.cs
+++ b/WebApplication1/Data/ApplicationDbContext.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace WebApplication1.Data
 {
-    public class ApplicationDbContext : IdentityDbContext
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser, ApplicationRole, string>
     {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options)


### PR DESCRIPTION
Fix ApplicationDbContext class, must specify User and Role custom classes. If not, a Add-Migration would create duplicated foreign keys in the database for the existing related Users and Roles tables.
Detected the problem when using a real database instead of storing data in files like in the original code, and after creating a Entity Framework data migration using "Add-Migration" in the package manager console.